### PR TITLE
check that options is a hashref

### DIFF
--- a/lib/Pandoc.pm
+++ b/lib/Pandoc.pm
@@ -54,7 +54,7 @@ sub pandoc(@) { ## no critic
 
 sub run {
     my $pandoc = shift;
-    my $opts   = ref $_[-1] ? pop @_ : {};
+    my $opts   = 'HASH' eq ref $_[-1] ? pop @_ : {};
     my @args   = @_;
 
     my $in  = $opts->{in};

--- a/t/file-objects.t
+++ b/t/file-objects.t
@@ -1,0 +1,25 @@
+use strict;
+use Test::More;
+use Test::Exception;
+use Pandoc;
+
+use subs qw[ path tempdir ];
+
+plan skip_all => 'pandoc executable required' unless pandoc;
+plan skip_all => 'Path::Tiny required' unless eval 'use Path::Tiny qw[ path tempdir ]; 1;';
+
+my $dir = tempdir( CLEANUP => 1 );
+
+(my $input = $dir->child('input.md'))->spew_utf8(<<'DUMMY_TEXT');
+## Eius Ut
+
+Qui aut voluptate minima.
+DUMMY_TEXT
+note $input->slurp_utf8;
+
+my $output = $dir->child('output.html');
+
+lives_ok { pandoc->run(-o => $output, $input) } 'call pandoc with file objects as arguments';
+note $output->slurp_utf8;
+
+done_testing;


### PR DESCRIPTION
check that options is a hashref so that Path::Tiny/similar objects as arguments don't cause error

I did this more or less immediately:

``` perl
use Pandoc;
use Path::Tiny;

my $input = path 'path/to/some_file.md';
my $output = path $input =~ s/\.md$/.pdf/r;

pandoc->run( $input, -o => $output );
```

and got an error because the last argument was a reference but not a hashref.

I changed the code so that run() checks for a _hash_ ref before popping the options.

If you think this needs to be documented I'll do that too.
