### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: perl
+arch:
+ - amd64
+ - ppc64le
 perl:
   - "5.26"
   - "5.24"
@@ -10,7 +13,7 @@ perl:
 
 # Ubuntu 14.04 includes pandoc 1.12.2.1 so better use it
 sudo: required
-dist: trusty
+dist: xenial
 
 install:
   - sudo apt-get install pandoc


### PR DESCRIPTION
Hi,
I had added ppc64le support on Travis-ci and Its been success added and build. Kindly review and merge same.

Changes done are added ppc64le arch and updated Dist to Xenial

The Travis ci build logs can be verified from the link below.
https://travis-ci.com/github/zazzel/Pandoc-Wrapper
Please have a look.

Thank you
